### PR TITLE
add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+output: target/release/tap
+
+.PHONY: install clean
+
+INSTALL_DIR = /usr/local/bin
+
+target/release/tap: src
+	@cargo build --release
+
+install: /usr/local/bin/tap
+/usr/local/bin/tap: target/release/tap
+	@install -pm755 target/release/tap $(INSTALL_DIR)
+
+clean:
+	@cargo clean
+	@$(RM) $(INSTALL_DIR)/tap


### PR DESCRIPTION
Have a makefile.

Putting ~/.cargo/bin in one's path feels like a bit of a mess, so I've made the default installation `/usr/local/bin`.