### PR TITLE
manpage touchups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ output: target/release/tap target/release/man
 
 VERSION := $(shell git tag | tail -n 1 | tr -d v)
 
+YEAR := $(shell date +%Y)
+
 INSTALL_DIR = /usr/local/bin
 MAN_DIR = /usr/local/share/man
 
@@ -15,10 +17,10 @@ install: /usr/local/bin/tap man
 	@install -pm755 target/release/tap $(INSTALL_DIR)
 
 target/release/man: doc/tap.1
-	@echo '.TH "TAP" "1" "2023" "$(VERSION)" "User Commands"' > target/release/man
+	@echo '.TH "TAP" "1" "$(YEAR)" "$(VERSION)" "User Commands"' > target/release/man
 	@cat doc/tap.1 >> target/release/man
 
-man: $(MAN_DIR)/man1
+man: $(MAN_DIR)/man1/tap.1
 $(MAN_DIR)/man1/tap.1: target/release/man
 	@mkdir -p $(MAN_DIR)/man1
 	@install -pm644 target/release/man $(MAN_DIR)/man1/tap.1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-output: target/release/tap
+output: target/release/tap target/release/man
 
 .PHONY: install clean man
 
@@ -18,12 +18,10 @@ target/release/man: doc/tap.1
 	@echo '.TH "TAP" "1" "2023" "$(VERSION)" "User Commands"' > target/release/man
 	@cat doc/tap.1 >> target/release/man
 
-man: /usr/local/share/man/man1
-$(MAN_DIR)/man1: target/release/man
+man: $(MAN_DIR)/man1
+$(MAN_DIR)/man1/tap.1: target/release/man
 	@mkdir -p $(MAN_DIR)/man1
 	@install -pm644 target/release/man $(MAN_DIR)/man1/tap.1
-	@$(shell command -v mandb >/dev/null && mandb )
-	@$(shell command -v makewhatis >/dev/null && makewhatis )
 
 clean:
 	@cargo clean

--- a/doc/tap.1
+++ b/doc/tap.1
@@ -1,4 +1,3 @@
-.TH TAP 1
 .SH NAME
 tap \- TUI audio player
 .SH SYNOPSIS


### PR DESCRIPTION
I messed up some of the manpage formatting last time.

Also, the command to update the man database can fail at times, prompting a really non-obvious error, so I've just removed the commands to refresh any mandb.

The year in the man page was hard-coded, so I've added this as a variable.